### PR TITLE
Invalidate cache when environmentID changes

### DIFF
--- a/bullet-train-core.js
+++ b/bullet-train-core.js
@@ -143,7 +143,7 @@ const BulletTrain = class {
                     if (res) {
                         try {
                             var json = JSON.parse(res);
-                            if (json && json.api === this.api) {
+                            if (json && json.api === this.api && json.environmentID === this.environmentID) {
                                 this.setState(json);
                                 this.log("Retrieved flags from cache", json);
                             }


### PR DESCRIPTION
When a cache is being used and then for some reason the `environmentID` changes, we get stuck in the old `environmentID` and the new value passed in `init` is ignored. This PR intends to solve that checking by both `api` and `environmentID`.